### PR TITLE
fixes related to google sync and removal of google sync

### DIFF
--- a/src/views/SynchronizeView2.mxml
+++ b/src/views/SynchronizeView2.mxml
@@ -45,6 +45,8 @@ Not the initial setup of sync settings, meaning Synchronizeview shown when googl
 			
 			import myComponents.AlertPopUp;
 			
+			import utilities.Synchronize;
+			
 			[Bindable]
 			private var back_label:String;
 			private var alertPopUp:AlertPopUp;
@@ -107,6 +109,7 @@ Not the initial setup of sync settings, meaning Synchronizeview shown when googl
 						trace("night scout api secret reset to blanc, Synchronizeview2");
 						Settings.getInstance().setSetting(Settings.SettingsNightScoutAPISECRET,Settings.NightScoutDefaultAPISECRET);//also nightscoutsync is reset
 						Settings.getInstance().setSetting(Settings.SettingsLastNightScoutSyncTimeStamp,"0");
+						Synchronize.removeGoogleSync();
 						alertPopUp = new AlertPopUp();
 						alertPopUp.addEventListener(PopUpEvent.CLOSE, okClicked);
 						alertPopUp.show(this);
@@ -125,6 +128,7 @@ Not the initial setup of sync settings, meaning Synchronizeview shown when googl
 						alertPopUp.removeEventListener(PopUpEvent.CLOSE, okClicked);
 					}
 				}
+				navigator.popView();
 			}
 
 			


### PR DESCRIPTION
- check on access_token length was wrong
- when removing google sync, also reset tablenames, lastsynctimestamp
- when removing google sync, go back to previous settings screen
- throttling the calls to https://www.googleapis.com/fusiontables/v2/query, max 1 every 2,1 seconds (Google limits to 30 per minute)
- in case a rate limit is still exceeded, then wait for 2,1 seconds (should because it blocks the UI)
- there's also reformatting/correction of source indentation probably
- made some variables static (wasn't necessary)
